### PR TITLE
Auto-detect aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,20 @@
 A style for [import-sort](https://github.com/renke/import-sort) that is focused
 on modules with relative modules alias support.
 
+## Migrating from v1 to v2
+
+Previously, we had to fill an `alias` option with the aliases list (e.g. `["components", "modules"]`).
+
+Now it auto-detects aliases using the following combined rules:
+
+- Aliases are absolute modules: `isAbsoluteModule`
+- Aliases aren't node modules: `not(isNodeModule)`
+
 ## Options
 
-| Name                   | Type     | Description                                                       | Default value |
-| ---------------------- | -------- | ----------------------------------------------------------------- | ------------- |
-| alias                  | string[] | List of resolver aliases                                          | []            |
-| overrideBuiltInModules | boolean  | Whether an alias should override a Node built-in module (e.g. fs) | true          |
+| Name                   | Type    | Description                                                       | Default value |
+| ---------------------- | ------- | ----------------------------------------------------------------- | ------------- |
+| overrideBuiltInModules | boolean | Whether an alias should override a Node built-in module (e.g. fs) | true          |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,9 @@ Previously, we had to fill an `alias` option with the aliases list (e.g. `["comp
 
 Now it auto-detects aliases using the following combined rules:
 
-- Aliases are absolute modules: `isAbsoluteModule`
-- Aliases aren't node modules: `not(isNodeModule)`
-
-## Options
-
-| Name                   | Type    | Description                                                       | Default value |
-| ---------------------- | ------- | ----------------------------------------------------------------- | ------------- |
-| overrideBuiltInModules | boolean | Whether an alias should override a Node built-in module (e.g. fs) | true          |
+- Aliased imports are absolute modules (e.g. `foo`): `isAbsoluteModule`
+- Aliased imports aren't installed modules (e.g. `react`): `not(isInstalledModule(file))`
+- Aliased imports aren't node modules (e.g. `fs`): `not(isNodeModule)`
 
 ## Configuration
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,7 @@ export interface Options {
   overrideBuiltinModules: boolean;
 }
 
-export default (
-  styleApi: IStyleAPI,
-  _file?: string,
-  { overrideBuiltinModules = true } = {} as Options
-): IStyleItem[] => {
+export default (styleApi: IStyleAPI, file: string): IStyleItem[] => {
   const {
     alias,
     and,
@@ -16,22 +12,26 @@ export default (
     hasNoMember,
     isNodeModule,
     isAbsoluteModule,
+    isInstalledModule,
     isRelativeModule,
     moduleName,
     naturally,
     not,
+    or,
     unicode,
   } = styleApi;
 
-  const isAliasModule = not(isNodeModule);
+  const isExternalModule = or(isNodeModule, isInstalledModule(file));
 
   return [
     // import "foo"
-    { match: and(hasNoMember, isAbsoluteModule, not(isAliasModule)) },
+    {
+      match: and(hasNoMember, isAbsoluteModule, isExternalModule),
+    },
     { separator: true },
 
     // import "{relativeAlias}/foo"
-    { match: and(hasNoMember, isAbsoluteModule, isAliasModule) },
+    { match: and(hasNoMember, isAbsoluteModule, not(isExternalModule)) },
     { separator: true },
 
     // import "./foo"
@@ -40,9 +40,7 @@ export default (
 
     // import … from "fs";
     {
-      match: overrideBuiltinModules
-        ? and(isNodeModule, not(isAliasModule))
-        : isNodeModule,
+      match: isNodeModule,
       sort: moduleName(naturally),
       sortNamedMembers: alias(unicode),
     },
@@ -50,7 +48,7 @@ export default (
 
     // import … from "foo";
     {
-      match: and(isAbsoluteModule, not(isAliasModule)),
+      match: and(isAbsoluteModule, isInstalledModule(file)),
       sort: moduleName(naturally),
       sortNamedMembers: alias(unicode),
     },
@@ -58,7 +56,7 @@ export default (
 
     // import … from "{relativeAlias}/foo";
     {
-      match: and(isAbsoluteModule, isAliasModule),
+      match: and(isAbsoluteModule, not(isExternalModule)),
       sort: moduleName(naturally),
       sortNamedMembers: alias(unicode),
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,13 @@
-import { IImport } from 'import-sort-parser';
 import { IStyleAPI, IStyleItem } from 'import-sort-style';
 
 export interface Options {
-  alias: string[];
   overrideBuiltinModules: boolean;
 }
-
-const hasAlias = (aliases: string[]) => (imported: IImport): boolean =>
-  aliases.some(
-    (alias: string): boolean =>
-      imported.moduleName === alias ||
-      imported.moduleName.indexOf(`${alias}/`) === 0
-  );
 
 export default (
   styleApi: IStyleAPI,
   _file?: string,
-  { alias: aliases = [], overrideBuiltinModules = true } = {} as Options
+  { overrideBuiltinModules = true } = {} as Options
 ): IStyleItem[] => {
   const {
     alias,
@@ -32,7 +23,7 @@ export default (
     unicode,
   } = styleApi;
 
-  const isAliasModule = hasAlias(aliases || []);
+  const isAliasModule = not(isNodeModule);
 
   return [
     // import "foo"


### PR DESCRIPTION
Closes #11

It adds auto-detection based on: `isAbsoluteModule`, `isNodeModule` and `isInstalledModule`.

An aliased import is an absolute module and is not a node module nor an installed module.

BREAKING CHANGE: `options.alias` and `options.overrideBuiltinModules` are no longer required/valid

This PR depends on https://github.com/ggascoigne/prettier-plugin-import-sort/pulls/23 to work fine with [prettier-plugin-import-sort](https://github.com/ggascoigne/prettier-plugin-import-sort), since it now depends on the file path to detect properly.